### PR TITLE
Fix division by 0 on single point draw, add DrawPixel.

### DIFF
--- a/LEDMatrix.cpp
+++ b/LEDMatrix.cpp
@@ -145,6 +145,9 @@ void cLEDMatrixBase::QuadrantBottomTriangleMirror()
   QuadrantMirror();
 }
 
+void cLEDMatrixBase::DrawPixel(int16_t x, int16_t y, CRGB Col) {
+  DrawLine(x, y, x, y, Col);
+}
 
 void cLEDMatrixBase::DrawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, CRGB Col)
 {
@@ -152,17 +155,22 @@ void cLEDMatrixBase::DrawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, CR
   int16_t dy = y1 - y0;
   if (abs(dx) >= abs(dy))
   {
-    int32_t f = ((int32_t)dy << 16) / (int32_t)abs(dx);
     int32_t y = ((int32_t)y0 << 16) + 32768;
-    if (dx >= 0)
-    {
-      for (; x0<=x1; ++x0,y+=f)
-        (*this)(x0, (y >> 16)) = Col;
-    }
-    else
-    {
-      for (; x0>=x1; --x0,y+=f)
-        (*this)(x0, (y >> 16)) = Col;
+    // Support a single dot line without diving by 0 and crashing below
+    if (!dx) {
+      (*this)(x0, (y >> 16)) = Col;
+    } else {
+      int32_t f = ((int32_t)dy << 16) / (int32_t)abs(dx);
+      if (dx >= 0)
+      {
+        for (; x0<=x1; ++x0,y+=f)
+          (*this)(x0, (y >> 16)) = Col;
+      }
+      else
+      {
+        for (; x0>=x1; --x0,y+=f)
+          (*this)(x0, (y >> 16)) = Col;
+      }
     }
   }
   else

--- a/LEDMatrix.h
+++ b/LEDMatrix.h
@@ -48,6 +48,7 @@ class cLEDMatrixBase
     void QuadrantTopTriangleMirror();
     void QuadrantBottomTriangleMirror();
 
+    void DrawPixel(int16_t x, int16_t y, CRGB Col);
     void DrawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, CRGB Col);
     void DrawRectangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, CRGB Col);
     void DrawCircle(int16_t xc, int16_t yc, uint16_t r, CRGB Col);

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ void TriangleBottomMirror(bool FullHeight = true)
 void QuadrantTopTriangleMirror()
 void QuadrantBottomTriangleMirror()
 
+void DrawPixel(int16_t x, int16_t y, CRGB color)
 void DrawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, CRGB color)
 void DrawRectangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, CRGB color)
 void DrawCircle(int16_t xc, int16_t yc, uint16_t r, CRGB color)


### PR DESCRIPTION
Both DrawLine and DrawFillCircle crash if they end up drawing a single pixel due to a division by 0.
Also add missing DrawPixel method.
@Aaron Liddiment  this bug likely affects your tree too.