### PR TITLE
Support Matrices with more than 32K pixels.

### DIFF
--- a/LEDMatrix.h
+++ b/LEDMatrix.h
@@ -28,7 +28,7 @@ class cLEDMatrixBase
 
   public:
     cLEDMatrixBase();
-    virtual uint16_t mXY(uint16_t x, uint16_t y)=0;
+    virtual uint32_t mXY(uint16_t x, uint16_t y)=0;
     void SetLEDArray(struct CRGB *pLED);	// Only used with externally defined LED arrays
 
     struct CRGB *operator[](int n);
@@ -88,7 +88,7 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
       p_LED = pLED;
       m_LED = pLED;
     }
-    virtual uint16_t mXY(uint16_t x, uint16_t y)
+    virtual uint32_t mXY(uint16_t x, uint16_t y)
     {
 			if ((tBWidth == 1) && (tBHeight == 1))
 			{
@@ -362,20 +362,20 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
   	// Optimised functions used by ShiftLeft & ShiftRight in non block mode
     void HPWSL(void)
     {
-      int16_t i = 0;
+      uint32_t i = 0;
       for (int16_t y=m_absMHeight; y>0; --y,++i)
       {
-        for (int16_t x=m_absMWidth-1; x>0; --x,++i)
+        for (uint16_t x=m_absMWidth-1; x>0; --x,++i)
           p_LED[i] = p_LED[i + 1];
         p_LED[i] = CRGB(0, 0, 0);
       }
     }
     void HNWSL(void)
     {
-      int16_t i = m_absMWidth - 1;
+      uint32_t i = m_absMWidth - 1;
       for (int16_t y=m_absMHeight; y>0; --y)
       {
-        for (int16_t x=m_absMWidth-1; x>0; --x,--i)
+        for (uint16_t x=m_absMWidth-1; x>0; --x,--i)
           p_LED[i] = p_LED[i - 1];
         p_LED[i] = CRGB(0, 0, 0);
         i += ((m_absMWidth * 2) - 1);
@@ -383,9 +383,9 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
     }
     void VPWSL(void)
     {
-      int16_t i = 0;
-      int16_t j = m_absMHeight;
-      for (int16_t x=m_absMWidth-1; x>0; --x)
+      uint32_t i = 0;
+      uint32_t j = m_absMHeight;
+      for (uint16_t x=m_absMWidth-1; x>0; --x)
       {
         for (int16_t y=m_absMHeight; y>0; --y)
           p_LED[i++] = p_LED[j++];
@@ -395,9 +395,9 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
     }
     void VNWSL(void)
     {
-      int16_t i = (m_absMHeight * m_absMWidth) - 1;
-      int16_t j = i - m_absMHeight;
-      for (int16_t x=m_absMWidth-1; x>0; --x)
+      uint32_t i = (m_absMHeight * m_absMWidth) - 1;
+      uint32_t j = i - m_absMHeight;
+      for (uint16_t x=m_absMWidth-1; x>0; --x)
       {
         for (int16_t y=m_absMHeight; y>0; --y)
           p_LED[i--] = p_LED[j--];
@@ -407,17 +407,17 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
     }
     void HZPWSL(void)
     {
-      int16_t i = 0;
+      uint32_t i = 0;
       for (int16_t y=m_absMHeight; y>0; y-=2)
       {
-        for (int16_t x=m_absMWidth-1; x>0; --x,++i)
+        for (uint16_t x=m_absMWidth-1; x>0; --x,++i)
           p_LED[i] = p_LED[i + 1];
         p_LED[i] = CRGB(0, 0, 0);
         i++;
         if (y > 1)
         {
           i += (m_absMWidth - 1);
-          for (int16_t x=m_absMWidth-1; x>0; --x,--i)
+          for (uint16_t x=m_absMWidth-1; x>0; --x,--i)
             p_LED[i] = p_LED[i - 1];
           p_LED[i] = CRGB(0, 0, 0);
           i += m_absMWidth;
@@ -426,16 +426,16 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
     }
     void HZNWSL(void)
     {
-      int16_t i = m_absMWidth - 1;
+      uint32_t i = m_absMWidth - 1;
       for (int16_t y=m_absMHeight; y>0; y-=2)
       {
-        for (int16_t x=m_absMWidth-1; x>0; --x,--i)
+        for (uint16_t x=m_absMWidth-1; x>0; --x,--i)
           p_LED[i] = p_LED[i - 1];
         p_LED[i] = CRGB(0, 0, 0);
         if (y > 1)
         {
           i += m_absMWidth;
-          for (int16_t x=m_absMWidth-1; x>0; --x,++i)
+          for (uint16_t x=m_absMWidth-1; x>0; --x,++i)
             p_LED[i] = p_LED[i + 1];
           p_LED[i] = CRGB(0, 0, 0);
           i += m_absMWidth;
@@ -444,9 +444,9 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
     }
     void VZPWSL(void)
     {
-      int16_t i = 0;
-      int16_t j = (m_absMHeight * 2) - 1;
-      for (int16_t x=m_absMWidth-1; x>0; x-=2)
+      uint32_t i = 0;
+      uint32_t j = (m_absMHeight * 2) - 1;
+      for (uint16_t x=m_absMWidth-1; x>0; x-=2)
       {
         for (int16_t y=m_absMHeight; y>0; --y)
           p_LED[i++] = p_LED[j--];
@@ -463,9 +463,9 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
     }
     void VZNWSL(void)
     {
-      int16_t i = (m_absMHeight * m_absMWidth) - 1;
-      int16_t j = m_absMHeight * (m_absMWidth - 2);
-      for (int16_t x=m_absMWidth-1; x>0; x-=2)
+      uint32_t i = (m_absMHeight * m_absMWidth) - 1;
+      uint32_t j = m_absMHeight * (m_absMWidth - 2);
+      for (uint16_t x=m_absMWidth-1; x>0; x-=2)
       {
         for (int16_t y=m_absMHeight; y>0; --y)
           p_LED[i--] = p_LED[j++];
@@ -484,44 +484,44 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
   	// Optimised functions used by ShiftDown & ShiftUp in non block mode
     void HPHSD(void)
     {
-      int16_t i = 0;
-      int16_t j = m_absMWidth;
-      for (int16_t y=m_absMHeight-1; y>0; --y)
+      uint32_t i = 0;
+      uint32_t j = m_absMWidth;
+      for (uint16_t y=m_absMHeight-1; y>0; --y)
       {
-        for (int16_t x=m_absMWidth; x>0; --x)
+        for (uint16_t x=m_absMWidth; x>0; --x)
           p_LED[i++] = p_LED[j++];
       }
-      for (int16_t x=m_absMWidth; x>0; --x)
+      for (uint16_t x=m_absMWidth; x>0; --x)
         p_LED[i++] = CRGB(0, 0, 0);
     }
     void HNHSD(void)
     {
-      int16_t i = (m_absMWidth * m_absMHeight) - 1;
-      int16_t j = i - m_absMWidth;
-      for (int16_t y=m_absMHeight-1; y>0; --y)
+      uint32_t i = (m_absMWidth * m_absMHeight) - 1;
+      uint32_t j = i - m_absMWidth;
+      for (uint16_t y=m_absMHeight-1; y>0; --y)
       {
-        for (int16_t x=m_absMWidth; x>0; --x)
+        for (uint16_t x=m_absMWidth; x>0; --x)
           p_LED[i--] = p_LED[j--];
       }
-      for (int16_t x=m_absMWidth; x>0; --x)
+      for (uint16_t x=m_absMWidth; x>0; --x)
         p_LED[i--] = CRGB(0, 0, 0);
     }
     void VPHSD(void)
     {
-      int16_t i = 0;
-      for (int16_t x=m_absMWidth; x>0; --x,++i)
+      uint32_t i = 0;
+      for (uint16_t x=m_absMWidth; x>0; --x,++i)
       {
-        for (int16_t y=m_absMHeight-1; y>0; --y,++i)
+        for (uint16_t y=m_absMHeight-1; y>0; --y,++i)
           p_LED[i] = p_LED[i + 1];
         p_LED[i] = CRGB(0, 0, 0);
       }
     }
     void VNHSD(void)
     {
-      int16_t i = m_absMHeight - 1;
-      for (int16_t x=m_absMWidth; x>0; --x)
+      uint32_t i = m_absMHeight - 1;
+      for (uint16_t x=m_absMWidth; x>0; --x)
       {
-        for (int16_t y=m_absMHeight-1; y>0; --y,--i)
+        for (uint16_t y=m_absMHeight-1; y>0; --y,--i)
           p_LED[i] = p_LED[i - 1];
         p_LED[i] = CRGB(0, 0, 0);
         i += ((m_absMHeight * 2) - 1);
@@ -529,55 +529,55 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
     }
     void HZPHSD(void)
     {
-      int16_t i = 0;
-      int16_t j = (m_absMWidth * 2) - 1;
-      for (int16_t y=m_absMHeight-1; y>0; y-=2)
+      uint32_t i = 0;
+      uint32_t j = (m_absMWidth * 2) - 1;
+      for (uint16_t y=m_absMHeight-1; y>0; y-=2)
       {
-        for (int16_t x=m_absMWidth; x>0; --x)
+        for (uint16_t x=m_absMWidth; x>0; --x)
           p_LED[i++] = p_LED[j--];
         if (y > 1)
         {
           j += (m_absMWidth * 2);
-          for (int16_t x=m_absMWidth; x>0; --x)
+          for (uint16_t x=m_absMWidth; x>0; --x)
             p_LED[i++] = p_LED[j--];
           j += (m_absMWidth * 2);
         }
       }
-      for (int16_t x=m_absMWidth; x>0; x--)
+      for (uint16_t x=m_absMWidth; x>0; x--)
         p_LED[i++] = CRGB(0, 0, 0);
     }
     void HZNHSD(void)
     {
-      int16_t i = (m_absMWidth * m_absMHeight) - 1;
-      int16_t j = m_absMWidth * (m_absMHeight - 2);
-      for (int16_t y=m_absMHeight-1; y>0; y-=2)
+      uint32_t i = (m_absMWidth * m_absMHeight) - 1;
+      uint32_t j = m_absMWidth * (m_absMHeight - 2);
+      for (uint16_t y=m_absMHeight-1; y>0; y-=2)
       {
-        for (int16_t x=m_absMWidth; x>0; --x)
+        for (uint16_t x=m_absMWidth; x>0; --x)
           p_LED[i--] = p_LED[j++];
         if (y > 1)
         {
           j -= (m_absMWidth * 2);
-          for (int16_t x=m_absMWidth; x>0; --x)
+          for (uint16_t x=m_absMWidth; x>0; --x)
             p_LED[i--] = p_LED[j++];
           j -= (m_absMWidth * 2);
         }
       }
-      for (int16_t x=m_absMWidth; x>0; x--)
+      for (uint16_t x=m_absMWidth; x>0; x--)
         p_LED[i--] = CRGB(0, 0, 0);
     }
     void VZPHSD(void)
     {
-      int16_t i = 0;
-      for (int16_t x=m_absMWidth; x>0; x-=2)
+      uint32_t i = 0;
+      for (uint16_t x=m_absMWidth; x>0; x-=2)
       {
-        for (int16_t y=m_absMHeight-1; y>0; --y,++i)
+        for (uint16_t y=m_absMHeight-1; y>0; --y,++i)
           p_LED[i] = p_LED[i + 1];
         p_LED[i] = CRGB(0, 0, 0);
         i++;
         if (x > 1)
         {
           i += (m_absMHeight - 1);
-          for (int16_t y=m_absMHeight-1; y>0; --y,--i)
+          for (uint16_t y=m_absMHeight-1; y>0; --y,--i)
             p_LED[i] = p_LED[i - 1];
           p_LED[i] = CRGB(0, 0, 0);
           i += m_absMHeight;
@@ -586,16 +586,16 @@ template<int16_t tMWidth, int16_t tMHeight, MatrixType_t tMType, int8_t tBWidth 
     }
     void VZNHSD(void)
     {
-      int16_t i = m_absMHeight - 1;
-      for (int16_t x=m_absMWidth; x>0; x-=2)
+      uint32_t i = m_absMHeight - 1;
+      for (uint16_t x=m_absMWidth; x>0; x-=2)
       {
-        for (int16_t y=m_absMHeight-1; y>0; --y,--i)
+        for (uint16_t y=m_absMHeight-1; y>0; --y,--i)
           p_LED[i] = p_LED[i - 1];
         p_LED[i] = CRGB(0, 0, 0);
         if (x > 1)
         {
           i += m_absMHeight;
-          for (int16_t y=m_absMHeight-1; y>0; --y,++i)
+          for (uint16_t y=m_absMHeight-1; y>0; --y,++i)
             p_LED[i] = p_LED[i + 1];
           p_LED[i] = CRGB(0, 0, 0);
           i += m_absMHeight;


### PR DESCRIPTION
height and width can be bigger than 256 (ILI3941 is 320x240).
If the array is bigger than 32K, signed pointers in the 1D array got
negative and crashed the code.
Similarly mXY multiplies 2 uint16_t, so it should be uint32_t.